### PR TITLE
Add Elixir 1.12 / OTP 23 to test matrix

### DIFF
--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -17,8 +17,8 @@ jobs:
       MIX_ENV: test
     strategy:
       matrix:
-        elixir: ["1.11.4"]
-        otp: ["22.3"]
+        elixir: ["1.11.4", "1.12.3"]
+        otp: ["22.3", "23.3"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/elixir-dialyzer.yml
+++ b/.github/workflows/elixir-dialyzer.yml
@@ -17,8 +17,8 @@ jobs:
       MIX_ENV: dev
     strategy:
       matrix:
-        elixir: ["1.11.4"]
-        otp: ["22.3"]
+        elixir: ["1.11.4", "1.12.3"]
+        otp: ["22.3", "23.3"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ["1.11.4"]
-        otp: ["22.3"]
+        elixir: ["1.11.4", "1.12.3"]
+        otp: ["22.3", "23.3"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Expand the release matrix for CI as we move forward with elixir / OTP /
rustler versions.