### PR TITLE
Expand CI matrix to 1.13 / OTP 24

### DIFF
--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -17,8 +17,8 @@ jobs:
       MIX_ENV: test
     strategy:
       matrix:
-        elixir: ["1.11.4", "1.12.3"]
-        otp: ["22.3", "23.3"]
+        elixir: ["1.11.4", "1.12.3", "1.13.4"]
+        otp: ["22.3", "23.3", "24.3"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/elixir-dialyzer.yml
+++ b/.github/workflows/elixir-dialyzer.yml
@@ -17,8 +17,8 @@ jobs:
       MIX_ENV: dev
     strategy:
       matrix:
-        elixir: ["1.11.4", "1.12.3"]
-        otp: ["22.3", "23.3"]
+        elixir: ["1.11.4", "1.12.3", "1.13.4"]
+        otp: ["22.3", "23.3", "24.3"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ["1.11.4", "1.12.3"]
-        otp: ["22.3", "23.3"]
+        elixir: ["1.11.4", "1.12.3", "1.13.4"]
+        otp: ["22.3", "23.3", "24.3"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Expand the CI release matrix to cover elixir 1.13.x and erlang/OTP 24. This will allow us to verify compatibility with more recent versions of elixir and erlang.