### PR TITLE
Update rust gpgme

### DIFF
--- a/native/exgpgme/Cargo.lock
+++ b/native/exgpgme/Cargo.lock
@@ -13,15 +13,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "conv"
@@ -30,6 +30,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 dependencies = [
  "custom_derive",
+]
+
+[[package]]
+name = "cstr-argument"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
+dependencies = [
+ "cfg-if",
+ "memchr",
 ]
 
 [[package]]
@@ -43,48 +53,43 @@ name = "exgpgme"
 version = "0.1.0"
 dependencies = [
  "gpgme",
- "lazy_static 1.4.0",
+ "lazy_static",
  "rustler",
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
-
-[[package]]
 name = "gpg-error"
-version = "0.2.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c732e7f1b15b2e2a3c8be3ccdc8d645d3c22628901252318931fa54c1e13e08f"
+checksum = "7073b9ac823434ae73608715086e944d694a7ce2677371b8c5253300d1f767f1"
 dependencies = [
  "libgpg-error-sys",
 ]
 
 [[package]]
 name = "gpgme"
-version = "0.6.1"
-source = "git+https://github.com/johnschug/rust-gpgme.git#9df869c3bd2776241f3a4bca31029caf468b3c41"
+version = "0.10.0"
+source = "git+https://github.com/gpg-rs/gpgme.git#fb4108fb8f8069694d511e9b501feda27eb03fae"
 dependencies = [
  "bitflags",
- "cfg-if",
  "conv",
+ "cstr-argument",
  "gpg-error",
  "gpgme-sys",
- "lazy_static 0.2.9",
  "libc",
+ "once_cell",
+ "smallvec",
+ "static_assertions",
 ]
 
 [[package]]
 name = "gpgme-sys"
-version = "0.6.1"
-source = "git+https://github.com/johnschug/rust-gpgme.git#9df869c3bd2776241f3a4bca31029caf468b3c41"
+version = "0.10.0"
+source = "git+https://github.com/gpg-rs/gpgme.git#fb4108fb8f8069694d511e9b501feda27eb03fae"
 dependencies = [
- "cfg-if",
- "gcc",
  "libc",
  "libgpg-error-sys",
+ "winreg 0.9.0",
 ]
 
 [[package]]
@@ -92,12 +97,6 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
-name = "lazy_static"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
 
 [[package]]
 name = "lazy_static"
@@ -113,11 +112,12 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libgpg-error-sys"
-version = "0.2.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ef83893f1c49d4aaf751d0105b9c0120f385b8965c7437d0f024aeef5bbeb2"
+checksum = "ffb1aedf0efc5d25fdd08eb52b0759c71d02ac77fd1879b96e95211239528897"
 dependencies = [
- "gcc",
+ "libc",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -125,6 +125,12 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "proc-macro2"
@@ -167,7 +173,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e6617fa86bacfb2de792c12e261e0f456bb9ff15038498ae421715bf4128c5"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "rustler_codegen",
  "rustler_sys",
 ]
@@ -193,6 +199,18 @@ dependencies = [
  "regex",
  "unreachable",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -225,3 +243,43 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cdb3898397cf7f624c294948669beafaeebc5577d5ec53d0afb76633593597"
+dependencies = [
+ "winapi",
+]

--- a/native/exgpgme/Cargo.toml
+++ b/native/exgpgme/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["dylib"]
 [dependencies]
 rustler = "0.25.0"
 lazy_static = "1.4.0"
-gpgme = { git = "https://github.com/johnschug/rust-gpgme.git" }
+gpgme = { git = "https://github.com/gpg-rs/gpgme.git"}

--- a/native/exgpgme/src/context/mod.rs
+++ b/native/exgpgme/src/context/mod.rs
@@ -176,9 +176,9 @@ pub fn import<'a>(env: Env<'a>, context_arc: ResourceArc<resource::ContextNifRes
 
 #[rustler::nif(schedule = "DirtyIo")]
 pub fn find_key<'a>(env: Env<'a>, context_arc: ResourceArc<resource::ContextNifResource>, fingerprint: String) -> NifResult<Term<'a>> {
-    unpack_immutable_context!(context, context_arc);
+    unpack_mutable_context!(context, context_arc);
 
-    let result = try_gpgme!(context.find_key(fingerprint));
+    let result = try_gpgme!(context.get_key(fingerprint));
 
     Ok((atoms::ok(), keys::wrap_key(result)).encode(env))
 }

--- a/native/exgpgme/src/encrypt_flags.rs
+++ b/native/exgpgme/src/encrypt_flags.rs
@@ -17,14 +17,14 @@ pub fn arg_to_protocol(atoms: ListIterator) -> Result<EncryptFlags, Error> {
 
 pub fn string_to_flag(name: String) -> Result<EncryptFlags, Error> {
     match name.as_ref() {
-      "always_trust" => Ok(gpgme::ENCRYPT_ALWAYS_TRUST),
-      "expect_sign" => Ok(gpgme::ENCRYPT_EXPECT_SIGN),
-      "no_compress" => Ok(gpgme::ENCRYPT_NO_COMPRESS),
-      "no_encrypt_to" => Ok(gpgme::ENCRYPT_NO_ENCRYPT_TO),
-      "prepare" => Ok(gpgme::ENCRYPT_PREPARE),
-      "symmetric" => Ok(gpgme::ENCRYPT_SYMMETRIC),
-      "throw_keyids" => Ok(gpgme::ENCRYPT_THROW_KEYIDS),
-      "wrap" => Ok(gpgme::ENCRYPT_WRAP),
+      "always_trust" => Ok(gpgme::EncryptFlags::ALWAYS_TRUST),
+      "expect_sign" => Ok(gpgme::EncryptFlags::EXPECT_SIGN),
+      "no_compress" => Ok(gpgme::EncryptFlags::NO_COMPRESS),
+      "no_encrypt_to" => Ok(gpgme::EncryptFlags::NO_ENCRYPT_TO),
+      "prepare" => Ok(gpgme::EncryptFlags::PREPARE),
+      "symmetric" => Ok(gpgme::EncryptFlags::SYMMETRIC),
+      "throw_keyids" => Ok(gpgme::EncryptFlags::THROW_KEYIDS),
+      "wrap" => Ok(gpgme::EncryptFlags::WRAP),
       _ => Err(Error::BadArg)
     }
 }


### PR DESCRIPTION
Update the version of the gpgme rust library to the latest release
(0.10.0) at the new repository.