### PR TITLE
Import secret keys for tests

### DIFF
--- a/test/ex_gpgme/context_test.exs
+++ b/test/ex_gpgme/context_test.exs
@@ -194,7 +194,7 @@ defmodule ExGpgme.ContextTest do
   end
 
   describe "encrypt/2" do
-    @tag context: true, import_receiver_secret: true, armor: true
+    @tag context: true, import_all: true, armor: true
     test "encrypts correctly", %{context: context} do
       assert recipient = Context.find_key!(context, @receiver_fingerprint)
 
@@ -217,7 +217,7 @@ defmodule ExGpgme.ContextTest do
   end
 
   describe "decrypt/2" do
-    @tag context: true, import_receiver_secret: true, armor: true
+    @tag context: true, import_all: true, armor: true
     test "decrypts correctly", %{context: context} do
       assert {:ok, "Hello World!"} = Context.decrypt(context, @encrypted_receiver)
     end
@@ -281,7 +281,7 @@ defmodule ExGpgme.ContextTest do
   end
 
   describe "sign/3" do
-    @tag context: true, import_receiver_secret: true, armor: true
+    @tag context: true, import_all: true, armor: true
     test "creates correct signature", %{context: context} do
       assert {:ok, signature} = Context.sign(context, "Hello World")
       assert verification = Context.verify_opaque!(context, signature, "Hello World")


### PR DESCRIPTION
In order to maintain test compatibility with newer versions of gpgme,
import secret keys when testing decrypt/encrypt/sign operations. Without
these keys, gpgme will return a warning about the missing secret key.