### PR TITLE
Return enums

### DIFF
--- a/native/exgpgme/src/context/mod.rs
+++ b/native/exgpgme/src/context/mod.rs
@@ -7,6 +7,7 @@ use std::ops::Deref;
 use results::verification_result::transform_verification_result;
 use keys;
 use protocol;
+use protocol::XProtocol;
 use encrypt_flags;
 use engine;
 use pinentry_mode;
@@ -44,9 +45,9 @@ pub fn from_protocol(protocol_arg: Term) -> NifResult<FromProtocolResponse> {
 }
 
 #[rustler::nif]
-pub fn get_protocol(env: Env, context_arc: ResourceArc<resource::ContextNifResource>) -> NifResult<Term> {
+pub fn get_protocol(context_arc: ResourceArc<resource::ContextNifResource>) -> NifResult<XProtocol> {
     unpack_immutable_context!(context, context_arc);
-    Ok(protocol::protocol_to_nif(env, context.protocol()))
+    Ok(XProtocol(context.protocol()))
 }
 
 #[rustler::nif]

--- a/native/exgpgme/src/context/mod.rs
+++ b/native/exgpgme/src/context/mod.rs
@@ -10,6 +10,7 @@ use protocol;
 use encrypt_flags;
 use engine;
 use pinentry_mode;
+use pinentry_mode::XPinentryMode;
 use sign_mode;
 use results::import_result::transform_import_result;
 
@@ -148,9 +149,9 @@ pub fn set_engine_home_dir(context_arc: ResourceArc<resource::ContextNifResource
 
 
 #[rustler::nif]
-pub fn get_pinentry_mode(env: Env, context_arc: ResourceArc<resource::ContextNifResource>) -> NifResult<Term> {
+pub fn get_pinentry_mode(context_arc: ResourceArc<resource::ContextNifResource>) -> NifResult<XPinentryMode> {
     unpack_immutable_context!(context, context_arc);
-    Ok(pinentry_mode::pinentry_mode_to_term(context.pinentry_mode(), env))
+    Ok(XPinentryMode(context.pinentry_mode()))
 }
 
 

--- a/native/exgpgme/src/engine.rs
+++ b/native/exgpgme/src/engine.rs
@@ -2,7 +2,7 @@ use gpgme::engine::EngineInfo;
 use rustler::{Term, Env, Encoder};
 use rustler::types::elixir_struct;
 use std::str::Utf8Error;
-use protocol;
+use protocol::XProtocol;
 
 mod atoms {
     atoms! {
@@ -31,7 +31,7 @@ pub fn engine_info_to_term<'a>(engine_info: EngineInfo, env: Env<'a>) -> Result<
 
     Ok(
         elixir_struct::make_ex_struct(env, "Elixir.ExGpgme.Engine.EngineInfo").ok().unwrap()
-            .map_put(protocol_atom, protocol::protocol_to_nif(env, engine_info.protocol())).ok().unwrap()
+            .map_put(protocol_atom, XProtocol(engine_info.protocol()).encode(env)).ok().unwrap()
             .map_put(path_atom, get_engine_info(engine_info.path(), env)?).ok().unwrap()
             .map_put(home_dir_atom, get_engine_info(engine_info.home_dir(), env)?).ok().unwrap()
             .map_put(version_atom, get_engine_info(engine_info.version(), env)?).ok().unwrap()

--- a/native/exgpgme/src/hash_algorithm.rs
+++ b/native/exgpgme/src/hash_algorithm.rs
@@ -1,4 +1,4 @@
-use rustler::{Env, Term, Encoder};
+use rustler::Atom;
 use gpgme::HashAlgorithm;
 
 mod atoms {
@@ -22,23 +22,29 @@ mod atoms {
     }
 }
 
-pub fn transform_hash_algorithm(env: Env, algorithm: HashAlgorithm) -> Term {
+#[derive(NifUntaggedEnum)]
+pub enum HashAlgorithmResult {
+    Atom(Atom),
+    Tuple((Atom, u32))
+}
+
+pub fn transform_hash_algorithm(algorithm: HashAlgorithm) -> HashAlgorithmResult {
     match algorithm {
-        HashAlgorithm::None => atoms::none().encode(env),
-        HashAlgorithm::Md2 => atoms::md2().encode(env),
-        HashAlgorithm::Md4 => atoms::md4().encode(env),
-        HashAlgorithm::Md5 => atoms::md5().encode(env),
-        HashAlgorithm::Sha1 => atoms::sha1().encode(env),
-        HashAlgorithm::Sha224 => atoms::sha224().encode(env),
-        HashAlgorithm::Sha256 => atoms::sha256().encode(env),
-        HashAlgorithm::Sha384 => atoms::sha384().encode(env),
-        HashAlgorithm::Sha512 => atoms::sha512().encode(env),
-        HashAlgorithm::RipeMd160 => atoms::ripe_md160().encode(env),
-        HashAlgorithm::Tiger => atoms::tiger().encode(env),
-        HashAlgorithm::Haval => atoms::haval().encode(env),
-        HashAlgorithm::Crc32 => atoms::crc32().encode(env),
-        HashAlgorithm::Crc32Rfc1510 => atoms::crc32_rfc1510().encode(env),
-        HashAlgorithm::CrC24Rfc2440 => atoms::crc24_rfc2440().encode(env),
-        HashAlgorithm::Other(other) => (atoms::other(), other).encode(env),
+        HashAlgorithm::None => HashAlgorithmResult::Atom(atoms::none()),
+        HashAlgorithm::Md2 => HashAlgorithmResult::Atom(atoms::md2()),
+        HashAlgorithm::Md4 => HashAlgorithmResult::Atom(atoms::md4()),
+        HashAlgorithm::Md5 => HashAlgorithmResult::Atom(atoms::md5()),
+        HashAlgorithm::Sha1 => HashAlgorithmResult::Atom(atoms::sha1()),
+        HashAlgorithm::Sha224 => HashAlgorithmResult::Atom(atoms::sha224()),
+        HashAlgorithm::Sha256 => HashAlgorithmResult::Atom(atoms::sha256()),
+        HashAlgorithm::Sha384 => HashAlgorithmResult::Atom(atoms::sha384()),
+        HashAlgorithm::Sha512 => HashAlgorithmResult::Atom(atoms::sha512()),
+        HashAlgorithm::RipeMd160 => HashAlgorithmResult::Atom(atoms::ripe_md160()),
+        HashAlgorithm::Tiger => HashAlgorithmResult::Atom(atoms::tiger()),
+        HashAlgorithm::Haval => HashAlgorithmResult::Atom(atoms::haval()),
+        HashAlgorithm::Crc32 => HashAlgorithmResult::Atom(atoms::crc32()),
+        HashAlgorithm::Crc32Rfc1510 => HashAlgorithmResult::Atom(atoms::crc32_rfc1510()),
+        HashAlgorithm::CrC24Rfc2440 => HashAlgorithmResult::Atom(atoms::crc24_rfc2440()),
+        HashAlgorithm::Other(other) => HashAlgorithmResult::Tuple((atoms::other(), other)),
     }
 }

--- a/native/exgpgme/src/key_algorithm.rs
+++ b/native/exgpgme/src/key_algorithm.rs
@@ -1,4 +1,4 @@
-use rustler::{Atom, Encoder, Env, Term};
+use rustler::Atom;
 use gpgme::KeyAlgorithm;
 
 mod atoms {
@@ -17,18 +17,10 @@ mod atoms {
     }
 }
 
+#[derive(NifUntaggedEnum)]
 pub enum KeyAlgorithmResult {
     Atom(Atom),
     Tuple((Atom, u32))
-}
-
-impl Encoder for KeyAlgorithmResult {
-    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
-        match self {
-            KeyAlgorithmResult::Atom(atom) => atom.encode(env),
-            KeyAlgorithmResult::Tuple(tuple) => tuple.encode(env),
-        }
-    }
 }
 
 pub fn transform_key_algorithm(algorithm: KeyAlgorithm) -> KeyAlgorithmResult {

--- a/native/exgpgme/src/key_algorithm.rs
+++ b/native/exgpgme/src/key_algorithm.rs
@@ -1,4 +1,4 @@
-use rustler::{Env, Term, Encoder};
+use rustler::{Atom, Encoder, Env, Term};
 use gpgme::KeyAlgorithm;
 
 mod atoms {
@@ -17,18 +17,32 @@ mod atoms {
     }
 }
 
-pub fn transform_key_algorithm(env: Env, algorithm: KeyAlgorithm) -> Term {
+pub enum KeyAlgorithmResult {
+    Atom(Atom),
+    Tuple((Atom, u32))
+}
+
+impl Encoder for KeyAlgorithmResult {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        match self {
+            KeyAlgorithmResult::Atom(atom) => atom.encode(env),
+            KeyAlgorithmResult::Tuple(tuple) => tuple.encode(env),
+        }
+    }
+}
+
+pub fn transform_key_algorithm(algorithm: KeyAlgorithm) -> KeyAlgorithmResult {
     match algorithm {
-        KeyAlgorithm::Rsa => atoms::rsa().encode(env),
-        KeyAlgorithm::RsaEncrypt => atoms::rsa_encrypt().encode(env),
-        KeyAlgorithm::RsaSign => atoms::rsa_sign().encode(env),
-        KeyAlgorithm::ElgamalEncrypt => atoms::elgamal_encrypt().encode(env),
-        KeyAlgorithm::Dsa => atoms::dsa().encode(env),
-        KeyAlgorithm::Ecc => atoms::ecc().encode(env),
-        KeyAlgorithm::Elgamal => atoms::elgamal().encode(env),
-        KeyAlgorithm::Ecdsa => atoms::ecdsa().encode(env),
-        KeyAlgorithm::Ecdh => atoms::ecdh().encode(env),
-        KeyAlgorithm::Eddsa => atoms::eddsa().encode(env),
-        KeyAlgorithm::Other(other) => (atoms::other(), other).encode(env),
+        KeyAlgorithm::Rsa => KeyAlgorithmResult::Atom(atoms::rsa()),
+        KeyAlgorithm::RsaEncrypt => KeyAlgorithmResult::Atom(atoms::rsa_encrypt()),
+        KeyAlgorithm::RsaSign => KeyAlgorithmResult::Atom(atoms::rsa_sign()),
+        KeyAlgorithm::ElgamalEncrypt => KeyAlgorithmResult::Atom(atoms::elgamal_encrypt()),
+        KeyAlgorithm::Dsa => KeyAlgorithmResult::Atom(atoms::dsa()),
+        KeyAlgorithm::Ecc => KeyAlgorithmResult::Atom(atoms::ecc()),
+        KeyAlgorithm::Elgamal => KeyAlgorithmResult::Atom(atoms::elgamal()),
+        KeyAlgorithm::Ecdsa => KeyAlgorithmResult::Atom(atoms::ecdsa()),
+        KeyAlgorithm::Ecdh => KeyAlgorithmResult::Atom(atoms::ecdh()),
+        KeyAlgorithm::Eddsa => KeyAlgorithmResult::Atom(atoms::eddsa()),
+        KeyAlgorithm::Other(other) => KeyAlgorithmResult::Tuple((atoms::other(), other)),
     }
 }

--- a/native/exgpgme/src/pinentry_mode.rs
+++ b/native/exgpgme/src/pinentry_mode.rs
@@ -14,14 +14,18 @@ mod atoms {
     }
 }
 
-pub fn pinentry_mode_to_term(pinentry_mode: PinentryMode, env: Env) -> Term {
-    match pinentry_mode {
-        PinentryMode::Default => atoms::default().encode(env),
-        PinentryMode::Ask => atoms::ask().encode(env),
-        PinentryMode::Cancel => atoms::cancel().encode(env),
-        PinentryMode::Error => atoms::error().encode(env),
-        PinentryMode::Loopback => atoms::loopback().encode(env),
-        PinentryMode::Other(other) => (atoms::other(), other).encode(env)
+pub struct XPinentryMode(pub PinentryMode);
+
+impl Encoder for XPinentryMode {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        match &self.0 {
+            PinentryMode::Default => atoms::default().encode(env),
+            PinentryMode::Ask => atoms::ask().encode(env),
+            PinentryMode::Cancel => atoms::cancel().encode(env),
+            PinentryMode::Error => atoms::error().encode(env),
+            PinentryMode::Loopback => atoms::loopback().encode(env),
+            PinentryMode::Other(other) => (atoms::other(), other).encode(env)
+        }
     }
 }
 

--- a/native/exgpgme/src/protocol.rs
+++ b/native/exgpgme/src/protocol.rs
@@ -18,6 +18,25 @@ mod atoms {
     }
 }
 
+pub struct XProtocol(pub Protocol);
+
+impl Encoder for XProtocol {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        match &self.0 {
+            Protocol::OpenPgp => atoms::open_pgp().encode(env),
+            Protocol::Cms => atoms::cms().encode(env),
+            Protocol::GpgConf => atoms::gpg_conf().encode(env),
+            Protocol::Assuan => atoms::assuan().encode(env),
+            Protocol::G13 => atoms::g13().encode(env),
+            Protocol::UiServer => atoms::ui_server().encode(env),
+            Protocol::Spawn => atoms::spawn().encode(env),
+            Protocol::Default => atoms::default().encode(env),
+            Protocol::Unknown => atoms::unknown().encode(env),
+            Protocol::Other(other) => (atoms::other(), other).encode(env)
+        }
+    }
+}
+
 pub fn arg_to_protocol(arg: Term) -> Result<Protocol, Error> {
     match arg.get_type() {
         TermType::Atom => {
@@ -46,20 +65,5 @@ pub fn arg_to_protocol(arg: Term) -> Result<Protocol, Error> {
             }
         },
         _ => Err(Error::BadArg)
-    }
-}
-
-pub fn protocol_to_nif(env: Env, protocol: Protocol) -> Term {
-    match protocol {
-        Protocol::OpenPgp => atoms::open_pgp().encode(env),
-        Protocol::Cms => atoms::cms().encode(env),
-        Protocol::GpgConf => atoms::gpg_conf().encode(env),
-        Protocol::Assuan => atoms::assuan().encode(env),
-        Protocol::G13 => atoms::g13().encode(env),
-        Protocol::UiServer => atoms::ui_server().encode(env),
-        Protocol::Spawn => atoms::spawn().encode(env),
-        Protocol::Default => atoms::default().encode(env),
-        Protocol::Unknown => atoms::unknown().encode(env),
-        Protocol::Other(other) => (atoms::other(), other).encode(env)
     }
 }

--- a/native/exgpgme/src/results/pka_trust.rs
+++ b/native/exgpgme/src/results/pka_trust.rs
@@ -1,4 +1,4 @@
-use rustler::{Env, Term, Encoder};
+use rustler::Atom;
 use gpgme::results::PkaTrust;
 
 mod atoms {
@@ -10,11 +10,17 @@ mod atoms {
     }
 }
 
-pub fn transform_pka_trust(env: Env, trust: PkaTrust) -> Term {
+#[derive(NifUntaggedEnum)]
+pub enum PkaTrustResult {
+    Atom(Atom),
+    Tuple((Atom, u32))
+}
+
+pub fn transform_pka_trust(trust: PkaTrust) -> PkaTrustResult {
     match trust {
-        PkaTrust::Unknown => atoms::unknown().encode(env),
-        PkaTrust::Bad => atoms::bad().encode(env),
-        PkaTrust::Okay => atoms::okay().encode(env),
-        PkaTrust::Other(other) => (atoms::other(), other).encode(env),
+        PkaTrust::Unknown => PkaTrustResult::Atom(atoms::unknown()),
+        PkaTrust::Bad => PkaTrustResult::Atom(atoms::bad()),
+        PkaTrust::Okay => PkaTrustResult::Atom(atoms::okay()),
+        PkaTrust::Other(other) => PkaTrustResult::Tuple((atoms::other(), other)),
     }
 }

--- a/native/exgpgme/src/results/signature.rs
+++ b/native/exgpgme/src/results/signature.rs
@@ -107,7 +107,7 @@ pub fn transform_signature<'a>(env: Env<'a>, signature: Signature) -> Result<Ter
             .map_put(pka_address_atom, pka_address).ok().unwrap()
             .map_put(validity_atom, transform_validity(signature.validity()).encode(env)).ok().unwrap()
             .map_put(nonvalidity_reason_atom, nonvalidity_reason).ok().unwrap()
-            .map_put(key_algorithm_atom, transform_key_algorithm(env, signature.key_algorithm())).ok().unwrap()
+            .map_put(key_algorithm_atom, transform_key_algorithm(signature.key_algorithm()).encode(env)).ok().unwrap()
             .map_put(hash_algorithm_atom, transform_hash_algorithm(env, signature.hash_algorithm())).ok().unwrap()
             .map_put(policy_url_atom, policy_url).ok().unwrap()
             .map_put(notations_atom, notations).ok().unwrap()

--- a/native/exgpgme/src/results/signature.rs
+++ b/native/exgpgme/src/results/signature.rs
@@ -103,7 +103,7 @@ pub fn transform_signature<'a>(env: Env<'a>, signature: Signature) -> Result<Ter
             .map_put(never_expires_atom, signature.never_expires().encode(env)).ok().unwrap()
             .map_put(is_wrong_key_usage_atom, signature.is_wrong_key_usage().encode(env)).ok().unwrap()
             .map_put(verified_by_chain_atom, signature.verified_by_chain().encode(env)).ok().unwrap()
-            .map_put(pka_trust_atom, transform_pka_trust(env, signature.pka_trust())).ok().unwrap()
+            .map_put(pka_trust_atom, transform_pka_trust(signature.pka_trust()).encode(env)).ok().unwrap()
             .map_put(pka_address_atom, pka_address).ok().unwrap()
             .map_put(validity_atom, transform_validity(signature.validity()).encode(env)).ok().unwrap()
             .map_put(nonvalidity_reason_atom, nonvalidity_reason).ok().unwrap()

--- a/native/exgpgme/src/results/signature.rs
+++ b/native/exgpgme/src/results/signature.rs
@@ -108,7 +108,7 @@ pub fn transform_signature<'a>(env: Env<'a>, signature: Signature) -> Result<Ter
             .map_put(validity_atom, transform_validity(signature.validity()).encode(env)).ok().unwrap()
             .map_put(nonvalidity_reason_atom, nonvalidity_reason).ok().unwrap()
             .map_put(key_algorithm_atom, transform_key_algorithm(signature.key_algorithm()).encode(env)).ok().unwrap()
-            .map_put(hash_algorithm_atom, transform_hash_algorithm(env, signature.hash_algorithm())).ok().unwrap()
+            .map_put(hash_algorithm_atom, transform_hash_algorithm(signature.hash_algorithm()).encode(env)).ok().unwrap()
             .map_put(policy_url_atom, policy_url).ok().unwrap()
             .map_put(notations_atom, notations).ok().unwrap()
             .map_put(key_atom, key_arc).ok().unwrap()


### PR DESCRIPTION
In order to clean up encoding and move it to actual nif functions, refactor transform functions that previous returned an encoded Term to instead return a more specific type.